### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,5 @@ end
 
 gem 'devise'
 gem 'active_hash'
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,10 +106,15 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.0.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -123,6 +128,7 @@ GEM
       activesupport (>= 5.0.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -134,6 +140,7 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.3)
@@ -236,6 +243,9 @@ GEM
     rubocop-ast (1.32.3)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.3.2)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -258,6 +268,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2024.2)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.6.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -290,8 +302,10 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  mini_magick
   mysql2 (~> 0.5)
   pg
   puma (~> 5.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,7 +27,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    # @item = Item.find(params[:id])
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -33,7 +33,7 @@ class Item < ApplicationRecord
                     }
 
   # 売り切れかどうかを判断するメソッド
-  # def sold_out?
-  # order.present? # 注文が存在すれば売り切れと判断
-  # end
+  def sold_out?
+    # order.present? # 注文が存在すれば売り切れと判断
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
     <% if @items.any? %>
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item) do %>
             <div class='item-img-content'>
               <%= image_tag (item.image.attached? ? item.image : "item-sample.png"), class: "item-img" %>
 
@@ -160,7 +160,7 @@
       <% end %>
     <% else %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to 'root_path' do %>
           <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
           <div class='item-info'>
             <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,13 +9,13 @@
     <div class="item-img-content">
       <%= image_tag @item.image, class: "item-box-img" %>  <%# 商品の画像を表示（必要に応じて修正） %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <% if @item.sold_out? %>
-        <div class="sold-out">
-          <span>Sold Out!!</span>
-        </div>
-      <% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
-    </div>
+  <%# <%= image_tag @item.image, class: "item-box-img"  商品の画像を表示（必要に応じて修正） %>
+  <%# if @item.sold_out? %>
+  <%#   <div class="sold-out"> %>
+  <%#     <span>Sold Out!!</span> %>
+  <%#   </div> %>
+  <%# end %>
+</div>
     <div class="item-price-box">
       ¥ <%= @item.price %>  <%# 商品価格を表示 %>
       </span>
@@ -26,10 +26,10 @@
 
     <% if user_signed_in? %>
       <% if @item.user == current_user && !@item.sold_out? %>
-        <%= link_to "商品の編集", "#", class: "item-red-btn" %>
-        <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, data: { confirm: "本当に削除しますか？" }, class: "item-destroy" %>
-      <% elsif @item.user != current_user && !@item.sold_out? %>
+       <%= link_to "商品の編集", "#", class: "item-red-btn" %>
+       <p class="or-text">or</p>
+       <%= link_to "削除", "#", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "item-destroy" %>
+    <% elsif @item.user != current_user %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>
     <% end %>
@@ -100,9 +100,6 @@
         後ろの商品 ＞
       </a>
     </div>
-    <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
     <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-    <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,108 +4,105 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>  <%# 商品名を表示 %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class: "item-box-img" %>  <%# 商品の画像を表示（必要に応じて修正） %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <% if @item.sold_out? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
+      ¥ <%= @item.price %>  <%# 商品価格を表示 %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shopping_fee.name %>  <%# 配送料の負担を表示 %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? %>
+      <% if @item.user == current_user && !@item.sold_out? %>
+        <%= link_to "商品の編集", "#", class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, data: { confirm: "本当に削除しますか？" }, class: "item-destroy" %>
+      <% elsif @item.user != current_user && !@item.sold_out? %>
+        <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
+      <% end %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span>商品説明</span>
+      <p><%= @item.description %></p>  <%# 商品の説明を表示 %>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>  <%# 出品者名を表示 %>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>  <%# カテゴリー名を表示 %>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>  <%# 商品の状態を表示 %>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shopping_fee.name %></td>  <%# 配送料の負担を表示 %>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.region.name %></td>  <%# 発送元の地域を表示 %>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shopping_day.name %></td>  <%# 発送日の目安を表示 %>
         </tr>
       </tbody>
     </table>
     <div class="option">
       <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <%= image_tag "star.png", class: "favorite-star-icon", width: "20", height: "20" %>
         <span>お気に入り 0</span>
       </div>
       <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <%= image_tag "flag.png", class: "report-flag-icon", width: "20", height: "20" %>
         <span>不適切な商品の通報</span>
       </div>
     </div>
-  </div>
-  <%# /商品の概要 %>
+    <%# /商品の概要 %>
 
-  <div class="comment-box">
-    <form>
-      <textarea class="comment-text"></textarea>
-      <p class="comment-warn">
-        相手のことを考え丁寧なコメントを心がけましょう。
-        <br>
-        不快な言葉遣いなどは利用制限や退会処分となることがあります。
-      </p>
-      <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
-      </button>
-    </form>
+    <div class="comment-box">
+      <form>
+        <textarea class="comment-text"></textarea>
+        <p class="comment-warn">
+          相手のことを考え丁寧なコメントを心がけましょう。
+          <br>
+          不快な言葉遣いなどは利用制限や退会処分となることがあります。
+        </p>
+        <button type="submit" class="comment-btn">
+          <%= image_tag "comment.png", class: "comment-flag-icon", width: "20", height: "25" %>
+          <span>コメントする</span>
+        </button>
+      </form>
+    </div>
+    <div class="links">
+      <a href="#" class="change-item-btn">
+        ＜ 前の商品
+      </a>
+      <a href="#" class="change-item-btn">
+        後ろの商品 ＞
+      </a>
+    </div>
+    <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+    <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+    <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   </div>
-  <div class="links">
-    <a href="#" class="change-item-btn">
-      ＜ 前の商品
-    </a>
-    <a href="#" class="change-item-btn">
-      後ろの商品 ＞
-    </a>
-  </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-</div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,11 +25,11 @@
     </div>
 
     <% if user_signed_in? %>
-      <% if @item.user == current_user && !@item.sold_out? %>
+      <% if @item.user == current_user %>
        <%= link_to "商品の編集", "#", class: "item-red-btn" %>
        <p class="or-text">or</p>
        <%= link_to "削除", "#", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "item-destroy" %>
-    <% elsif @item.user != current_user %>
+    <% else %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
-  resources :items, only: [:new, :create, :index] 
+  resources :items, only: [:new, :create, :index, :show] 
 end


### PR DESCRIPTION
# What
商品詳細ページを作成し、以下の要件を満たすように実装しました。
・商品名、商品画像、価格、配送料の負担、商品説明、出品者名、カテゴリー、商品の状態、発送元の地域、発送日の目安を表示。
・画像が正しく表示され、リンク切れがないことを確認。
・ログイン状態で自身が出品した商品については「商品の編集」「削除」ボタンを表示。
・ログイン状態で自身が出品していない商品については「購入画面に進む」ボタンを表示。
・ログアウト状態ではボタンが表示されないようにしました。

# Why
ユーザー体験の向上: 商品詳細ページを通じて、ユーザーが商品の情報を明確に把握できるようにするため。
セキュリティと適切なアクセス管理: 編集や削除ボタンを出品者のみに表示することで、他のユーザーからの不正な操作を防ぐため。
システムの整合性: ログイン状況や出品者に応じたボタン表示により、UIの一貫性を保ち、操作の混乱を避けるため。

以下、GYAZOのURLになります。
ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/42285c9fb3cc9346ce85a658e410ecda

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画  
https://gyazo.com/fd9296e2bcc521c8a8b14e28ef92e315

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/149b92b498fe43976510c3e49a4c3c0f