### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
   # 特定のアクションに対してユーザー認証を適用
-  before_action :authenticate_user!, only: [:new, :create, :edit]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :ensure_user, only: [:edit, :update]
 
   # トップページ用の処理
   def index
@@ -32,6 +34,19 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    # 画像が選択されていない場合は、画像の更新をスキップ
+    params[:item].delete(:image) if params[:item][:image].blank?
+
+    if @item.update(item_params)
+      redirect_to item_path(@item), notice: '商品情報を更新しました'
+    else
+      flash.now[:alert] = '商品の更新に失敗しました。必須項目を確認してください。'
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   # 特定のアクションに対してユーザー認証を適用
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit]
 
   # トップページ用の処理
   def index
@@ -30,7 +30,21 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def ensure_user
+    return if @item.user == current_user
+
+    redirect_to root_path, alert: '他のユーザーの商品は編集できません'
+  end
 
   # ストロングパラメータ
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,15 +29,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     # 画像が選択されていない場合は、画像の更新をスキップ
     params[:item].delete(:image) if params[:item][:image].blank?
 
@@ -51,14 +48,13 @@ class ItemsController < ApplicationController
 
   private
 
+  # 共通の@itemセットメソッド
   def set_item
     @item = Item.find(params[:id])
   end
 
   def ensure_user
-    return if @item.user == current_user
-
-    redirect_to root_path, alert: '他のユーザーの商品は編集できません'
+    redirect_to root_path, alert: '他のユーザーの商品は編集できません' unless @item.user == current_user
   end
 
   # ストロングパラメータ

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,11 +8,9 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
+    
+    <%= render 'shared/error_messages', model: @item %>
+    
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -146,7 +144,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する", class: "sell-btn" %>
-      <%= link_to 'もどる', "#", class: "back-btn" %>
+      <%= link_to 'もどる', item_path(@item), class: "back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -3,11 +3,11 @@ app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,23 +23,24 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id: "item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
+    
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class: "items-text", id: "item-name", placeholder: "商品名（必須 40文字まで)", maxlength: "40", value: @item.name %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class: "items-text", id: "item-info", placeholder: "商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "7", maxlength: "1000", value: @item.description %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +53,13 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, { class: "select-box", id: "item-category" }) %>
+        
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, { class: "select-box", id: "item-sales-status" }) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +75,19 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shopping-fee-status"}) %>
+        <%= f.collection_select(:shopping_fee_id, ShoppingFee.all, :id, :name, {}, { class: "select-box", id: "item-shopping-fee-status" }) %>
+        
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:region_id, Region.all, :id, :name, {}, { class: "select-box", id: "item-prefecture" }) %>
+        
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shopping_day_id, ShoppingDay.all, :id, :name, {}, { class: "select-box", id: "item-scheduled-delivery" }) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +105,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class: "price-input", id: "item-price", placeholder: "例）300", value: @item.price %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -138,10 +142,11 @@ app/assets/stylesheets/items/new.css %>
       </p>
     </div>
     <%# /注意書き %>
+    
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= f.submit "変更する", class: "sell-btn" %>
+      <%= link_to 'もどる', "#", class: "back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>
@@ -153,9 +158,9 @@ app/assets/stylesheets/items/new.css %>
       <li><a href="#">フリマ利用規約</a></li>
       <li><a href="#">特定商取引に関する表記</a></li>
     </ul>
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
     <p class="inc">
-      ©︎Furima,Inc.
+      ©︎Furima, Inc.
     </p>
   </footer>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 
     <% if user_signed_in? %>
       <% if @item.user == current_user %>
-       <%= link_to "商品の編集", "#", class: "item-red-btn" %>
+       <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
        <p class="or-text">or</p>
        <%= link_to "削除", "#", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "item-destroy" %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
-  resources :items, only: [:new, :create, :index, :show] 
+  resources :items do
+end
 end


### PR DESCRIPTION
# what
・商品情報の編集機能実装
・「もどる」ボタンのパスの設定
・アクセス制御（他者・売却済み商品の編集不可、未ログイン時はリダイレクト）
・エラーハンドリングと入力情報の保持
# why
・商品の更新を可能にすることで、ユーザーが出品内容を柔軟に管理・修正できるようにし、利便性を向上させるため。

・編集途中で戻りたい場合に正確に商品詳細ページへ遷移させ、意図しないページ遷移や編集データの破棄を避けるため。

・他ユーザーによる意図しないアクセスや不正編集を防ぎ、セキュリティとデータの信頼性を確保するため。

・ユーザーが入力エラーに対応しやすくすることで、再入力の手間を減らすため。

以下、GYAZOのURLになります。

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/0932ba0966cce4ecd68428906e407f74
必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/481b4e3b96b94e81f3d1467a4593bfb8

入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/58e56c4276ce9c671229e3b8ff537d24

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/c5305e80ac02fb37fd6cfe15604a4112

ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/80e2830ed1d01fbaf7454a8e3045d770

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/e23d2675a65ca467dc2a3db4cc3bc98c

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/7ce72dd9e291ac2a07904f72dce92e5b

