### PR TITLE
削除ボタンのパスの設定、アクションの定義

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   # 特定のアクションに対してユーザー認証を適用
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :ensure_user, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :ensure_user, only: [:edit, :update, :destroy]
 
   # トップページ用の処理
   def index
@@ -28,12 +28,15 @@ class ItemsController < ApplicationController
     end
   end
 
+  # 商品詳細ページを表示するアクション
   def show
   end
 
+  # 商品情報編集ページを表示するアクション
   def edit
   end
 
+  # 商品情報を更新するアクション
   def update
     # 画像が選択されていない場合は、画像の更新をスキップ
     params[:item].delete(:image) if params[:item][:image].blank?
@@ -46,6 +49,15 @@ class ItemsController < ApplicationController
     end
   end
 
+  # 商品を削除するアクション
+  def destroy
+    if @item.destroy
+      redirect_to root_path, notice: '商品が削除されました。'
+    else
+      redirect_to item_path(@item), alert: '商品の削除に失敗しました。'
+    end
+  end
+
   private
 
   # 共通の@itemセットメソッド
@@ -53,6 +65,7 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  # 他のユーザーが商品編集や削除をできないようにするためのメソッド
   def ensure_user
     redirect_to root_path, alert: '他のユーザーの商品は編集できません' unless @item.user == current_user
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if @item.user == current_user %>
        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
        <p class="or-text">or</p>
-       <%= link_to "削除", "#", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "item-destroy" %>
+       <%= link_to "削除", item_path(@item), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "item-destroy" %>
     <% else %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>


### PR DESCRIPTION
# What
ログイン状態で、かつ自身が出品した商品のみ削除可能とする
削除完了後にトップページへリダイレクトする

# Why
権限の制御：ログインユーザーのみ削除できるようにすることで、他のユーザーや未ログイン者が誤って（または悪意で）削除を行うことを防ぐため
ユーザー体験の向上：削除後にトップページに戻すことで、ユーザーに削除が完了したことを視覚的にわかりやすく通知し、スムーズな操作性を提供するため

以下、GYAZOのURLになります。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/edf953487a927c5438faab0e2f266fd7